### PR TITLE
Fixed "mv" command instructions

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -40,7 +40,7 @@
 
 ➜ chmod +x phpdox.phar
 
-➜ mv phpdox.phar /usr/local/bin
+➜ mv phpdox.phar /usr/local/bin/phpdox
 
 ➜ phpdox --version</strong>
 phpDox 0.5.0 - Copyright (C) 2010 - 2013 by Arne Blankerts</pre>


### PR DESCRIPTION
Fixed `mv phpdox.phar` command to match the following line `phpdox --version`. If it's moved as is, will return a `phpdox: command not found`. It's a super minor thing, but maybe it will help someone?
