### PR TITLE
Update the example xlm namespace

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -54,7 +54,7 @@ phpDox 0.5.0 - Copyright (C) 2010 - 2013 by Arne Blankerts</pre>
      <p>You need to write an XML configuration file (commonly named <code>phpdox.xml</code>) for your project in order to use phpDox. The <code>phpdox --skel</code> command helps with this task by generating a skeleton configuration file.</p>
      <p>For the purpose of this tutorial we use the following minimal example:</p>
      <pre><code>&lt;?xml version="1.0" encoding="utf-8" ?&gt;
-&lt;phpdox xmlns="http://phpdox.de/config"&gt;
+&lt;phpdox xmlns="http://phpdox.net/config"&gt;
   &lt;project name="Example" source="${basedir}/src" workdir="${basedir}/build/api/xml"&gt;
     &lt;collector backend="parser" /&gt;
     &lt;generator output="${basedir}/build/api"&gt;


### PR DESCRIPTION
Prevent this error :

```
An error occured while trying to load the configuration file:
    File './phpdox.xml' uses an outdated xml namespace. Please update the xmlns to 'http://phpdox.net/config'
```
