### PR TITLE
Fix link to README

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -44,7 +44,7 @@
      <h1>Documentation</h1>
      <section>
       <h2 id="installation-usage">Installation and Usage</h2>
-      <p>Please refer to the <a href="https://github.com/theseer/phpdox/blob/master/README.markdown">README.markdown page on github</a> for now.</p>
+      <p>Please refer to the <a href="https://github.com/theseer/phpdox/blob/master/README.md">README.md page on github</a> for now.</p>
      </section>
 
      <section>


### PR DESCRIPTION
Seems like this was changed in https://github.com/theseer/phpdox/commit/e23d890225f61f980fdd00469e25a771cd94ae93 but not reflected in the documentation.